### PR TITLE
Adjust import syntax

### DIFF
--- a/ios/RNLaunchImage.h
+++ b/ios/RNLaunchImage.h
@@ -1,5 +1,5 @@
 
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNLaunchImage : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
for the most recent version of react native (0.40 at time of post) - the proper import syntax has changed to:
```
#import <React/RCTBridgeModule.h>
```
The old syntax can not work in some project(will report `RCTBridgeModule.h file not found`) 